### PR TITLE
fix: highlight markdown autolinks

### DIFF
--- a/src/tokenizeMarkdown.js
+++ b/src/tokenizeMarkdown.js
@@ -69,6 +69,7 @@ const RE_ANGLE_BRACKET_CLOSE = /^>/
 const RE_ANGLE_BRACKET_ONLY = /^</
 const RE_ANGLE_BRACKET_OPEN = /^</
 const RE_ANGLE_BRACKET_OPEN_TAG = /^<(?!\s)/
+const RE_AUTOLINK = /^<([a-zA-Z][a-zA-Z\d+.-]{1,31}:[^<>\s]*)>/
 const RE_ANY_TEXT = /^[^\n]+/
 const RE_ATTRIBUTE_NAME = /^[a-zA-Z\d\-]+/
 const RE_BLOCK_COMMENT_CONTENT = /^.(?:.*?)(?=-->|$)/s
@@ -177,6 +178,19 @@ export const tokenizeLine = (line, lineState) => {
         if ((next = part.match(RE_BLOCK_COMMENT_START))) {
           token = TokenType.Comment
           state = State.InsideBlockComment
+        } else if ((next = part.match(RE_AUTOLINK))) {
+          const tokenLength = next[0].length
+          const linkUrl = next[1]
+          index += tokenLength
+          tokens.push(
+            TokenType.Punctuation,
+            1,
+            TokenType.MarkdownLinkUrl,
+            linkUrl.length,
+            TokenType.Punctuation,
+            1,
+          )
+          continue
         } else if ((next = part.match(RE_ANGLE_BRACKET_OPEN_TAG))) {
           token = TokenType.PunctuationTag
           state = State.AfterOpeningAngleBracket

--- a/test/baselines/link-in-angle-brackets.txt
+++ b/test/baselines/link-in-angle-brackets.txt
@@ -1,5 +1,12 @@
 Text
-PunctuationTag
-TagName
+Punctuation
+MarkdownLinkUrl
+Punctuation
+NewLine
+NewLine
 Text
-PunctuationTag
+Punctuation
+MarkdownLinkUrl
+Punctuation
+Text
+NewLine

--- a/test/cases/link-in-angle-brackets.md
+++ b/test/cases/link-in-angle-brackets.md
@@ -1,1 +1,3 @@
 Learn more about this package: <https://example.com>
+
+Further documentation can be found at <https://hello.hexdocs.pm/>.


### PR DESCRIPTION
Treat angle-bracket URI autolinks as Markdown links instead of HTML tags, preserving surrounding prose as text. Adds regression coverage for the reported HexDocs link syntax.